### PR TITLE
Adding possibility to scan only one image (-i)

### DIFF
--- a/src/main/java/org/whitesource/docker/CommandLineArgs.java
+++ b/src/main/java/org/whitesource/docker/CommandLineArgs.java
@@ -33,4 +33,7 @@ public class CommandLineArgs {
     @Parameter(names = "-c", description = "Config file path")
     String configFilePath = CONFIG_FILE_NAME;
 
+    @Parameter(names = "-i", description = "Docker image to be scanned")
+    String dockerImage = "";
+
 }

--- a/src/main/java/org/whitesource/docker/DockerAgent.java
+++ b/src/main/java/org/whitesource/docker/DockerAgent.java
@@ -68,6 +68,7 @@ public class DockerAgent extends CommandLineAgent {
     public static final int MAX_PER_ROUTE_CONNECTIONS = 10;
 
     // property keys for the configuration file
+    public static final String DOCKER_API_VERSION = "docker.apiVersion";
     public static final String DOCKER_URL = "docker.url";
     public static final String DOCKER_CERT_PATH = "docker.certPath";
     public static final String DOCKER_USERNAME = "docker.username";
@@ -132,6 +133,13 @@ public class DockerAgent extends CommandLineAgent {
      */
     private DockerClient buildDockerClient() {
         DockerClientConfig.DockerClientConfigBuilder configBuilder = DockerClientConfig.createDefaultConfigBuilder();
+
+        final String dockerApiVersion = config.getProperty(DOCKER_API_VERSION);
+        if (StringUtils.isNotBlank(dockerApiVersion)) {
+            logger.info("api version: {}", dockerApiVersion);
+            configBuilder.withVersion(dockerApiVersion);
+
+        }
         String dockerUrl = config.getProperty(DOCKER_URL);
         if (StringUtils.isBlank(dockerUrl)) {
             logger.error("Missing Docker URL");
@@ -203,12 +211,12 @@ public class DockerAgent extends CommandLineAgent {
             return projects;
         }
 
-        for (Container container : containers) {
-            if(!this.dockerImage.isEmpty() && forcedContainer.getId()!=container.getId()) continue;
-            
+        for (Container container : containers) {                   
             String containerId = container.getId().substring(0, SHORT_CONTAINER_ID_LENGTH);
             String containerName = getContainerName(container);
             String image = container.getImage();
+
+            if(!this.dockerImage.isEmpty() && !forcedContainer.getId().equalsIgnoreCase(container.getId())) continue;
             logger.info("Processing Container {} {} ({})", image, containerId, containerName);
 
             // create agent project info

--- a/src/main/java/org/whitesource/docker/Main.java
+++ b/src/main/java/org/whitesource/docker/Main.java
@@ -60,7 +60,7 @@ public class Main {
         root.setLevel(Level.toLevel(logLevel, Level.INFO));
 
         // run the agent
-        DockerAgent dockerAgent = new DockerAgent(configProps);
+        DockerAgent dockerAgent = new DockerAgent(configProps, commandLineArgs.dockerImage);
         dockerAgent.sendRequest();
     }
 


### PR DESCRIPTION
By addign "-i imagename" on the command line,
the image is pulled from the docker registry.
Next it is started with a bash running  to keep the container running
until the end of the scan.
After the scan, the container is stopped and deleted

This "-i" option is very usefull in a shared machine like a jenkins slave having multiple executors & running docker images. Otherwise without a -i option, the docker-agent will scan others containers potentially loaded by others jenkins jobs in parallel. The -i will limit the scan to a specific image to validate by creating a container dedicated for this task.

docker.apiVersion option also added in the whitesource docker-agent .config file to avoid this error when calling dockerClient.startContainerCmd(forcedContainer.getId()).exec() (in my case I set 1.23 in the config file to resolve this issue) :
> com.github.dockerjava.api.BadRequestException: {"message":"starting container with non-empty request body was deprecated since v1.10 and removed in v1.12"}
